### PR TITLE
Fixed typo variable name PublishDirDir to become PublishDir 

### DIFF
--- a/NHSISL.LibPostalClient/NHSISL.LibPostalClient.targets
+++ b/NHSISL.LibPostalClient/NHSISL.LibPostalClient.targets
@@ -40,7 +40,7 @@
 	<Target Name="PrepLibPostalPublish" AfterTargets="Publish">
 		<Message Importance="high" Text="Writing to folder $(PublishDir)"/>
 		<DownloadFile SourceUrl="https://github.com/NHSISL/LibPostalClient/releases/download/LibPostalData/LibpostalData.zip" DestinationFolder="$(PublishDir)"></DownloadFile>
-		<Unzip SourceFiles="$(PublishDirDir)\LibpostalData.zip" DestinationFolder="$(TargetDir)\Data" OverwriteReadOnlyFiles="true"></Unzip>
+		<Unzip SourceFiles="$(PublishDir)\LibpostalData.zip" DestinationFolder="$(TargetDir)\Data" OverwriteReadOnlyFiles="true"></Unzip>
 		<Delete Files="$(PublishDir)\LibpostalData.zip"></Delete>
 		<Copy SourceFiles="@(WindowsNativeFiles)" DestinationFolder="$(PublishDir)"/>
 		<Copy SourceFiles="@(LinuxNativeFiles)" DestinationFolder="$(PublishDir)"/>


### PR DESCRIPTION

Publish target failing due to wrong PublishDir variable name
It returns `error MSB3932: Failed to unzip file "\LibpostalData.zip" because the file does not exist or is inaccessible`
because the code was using variable PublishDirDir instead of PublishDir
