### PR TITLE
CONFIG: lock FluentAssertions in Dependabot config (ignore 8.x/9.x/10.x)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       prefix: "CONFIG"
     labels:
       - "dependencies"
+    ignore:
+        - dependency-name: "FluentAssertions"
+          versions: ["8.x", "9.x", "10.x", "*"]


### PR DESCRIPTION
Locks FluentAssertions in Dependabot config for LibPostalClient, keeping it on the `[7.2.2]` line (ignore `8.x`/`9.x`/`10.x`) per the .NET 10 modernisation standard.

- **CONFIG:** add `ignore` block for `FluentAssertions` in `.github/dependabot.yml`.

Small standalone change off `main`, independent of the .NET 10 uplift PR #84.

closes [AB#29903](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29903)